### PR TITLE
command+v instead of super+v for OS X

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["super+v"], "command": "css_to_sass" },
+  { "keys": ["command+v"], "command": "css_to_sass" },
 ]


### PR DESCRIPTION
Just a cosmetic change actually. But `super` is used for some "cross OS" key bindings. So `command` would be better to understand.
