### PR TITLE
[Fix] Disable plugin action for unexpected syntaxes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,8 @@
-[
-  { "keys": ["ctrl+v"], "command": "css_to_sass" }
-]
+ [{
+     "keys": ["ctrl+v"],
+     "command": "css_to_sass",
+     "context": [{
+         "key": "selector",
+         "operand": "source.stylus, source.sass"
+     }]
+ }]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,8 @@
-[
-  { "keys": ["command+v"], "command": "css_to_sass" }
-]
+ [{
+     "keys": ["command+v"],
+     "command": "css_to_sass",
+     "context": [{
+         "key": "selector",
+         "operand": "source.stylus, source.sass"
+     }]
+ }]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,8 @@
-[
-  { "keys": ["ctrl+v"], "command": "css_to_sass" }
-]
+ [{
+     "keys": ["ctrl+v"],
+     "command": "css_to_sass",
+     "context": [{
+         "key": "selector",
+         "operand": "source.stylus, source.sass"
+     }]
+ }]


### PR DESCRIPTION
### 1. Summary

I make, that `css_to_cass` command works only for SASS and Stylus.

### 2. Argumentation

CSS to SASS work for SASS and Stylus syntaxes. But for another syntaxes users don't need this plugin. And in another syntaxes (Python, Ruby, HTML and so on) users can use another actions for <kbd>Ctrl+V</kbd> (<kbd>⌘v</kbd> for Mac) shortcut.

### 3. Steps to reproduce

I copy any text → I paste this text, use <kbd>Ctrl+V</kbd> for:

1. Stylus or SASS syntax,
1. Any another syntax.

### 4. Behavior before pull request

**For** SASS/Stylus syntax:

```python
key evt: control+v
command: css_to_sass
True
```

_(or False instead of true)_

**For** any another syntax:

```python
key evt: control+v
command: css_to_sass
True
```

### 5. Behavior after pull request

**For** SASS/Stylus syntax:

```python
key evt: control+v
command: css_to_sass
True
```

**For** any another syntax:

```python
key evt: control+v
command: paste
```

### 6. Technical explanation

See:

+ [**Run Command According to Syntax**](https://forum.sublimetext.com/t/run-command-according-to-syntax/13810?u=sasha_chernykh)

### 7. Supported syntaxes

In Package Control site I find these syntaxes for Stylus and SASS:

+ [**SASS**](https://packagecontrol.io/packages/Sass)
+ [**Stylus**](https://github.com/billymoon/Stylus)

**If** another syntaxes **exists**:

    we need add scopes for them.

### 8. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Sublime Text Build 3143,
+ SASS 2015.06.09.15.02.18,
+ Stylus 2017.12.19.12.00.23,
+ CSS to SASS Converter 1.2.2

Thanks.